### PR TITLE
Add support for generating optional initializers

### DIFF
--- a/Sources/Spec/MethodSpec.swift
+++ b/Sources/Spec/MethodSpec.swift
@@ -90,7 +90,7 @@ open class MethodSpec: PoetSpec, MethodSpecProtocol {
         emitter.emit(modifiers: modifiers)
 
         let cbBuilder = CodeBlock.builder()
-        if name != "init" {
+        if name != "init" && name != "init?" {
             cbBuilder.add(literal: construct)
         }
         cbBuilder.add(literal: name)


### PR DESCRIPTION
The current implementation does not allow generating optional initializers because if the methode name does not exactly match "init" it well add the "func" literal. 

By also checking for equality with "init?" it is also possible to generate optional initializers