### PR TITLE
Improve escaping swift keywords, fix latest XCode versions warnings f…

### DIFF
--- a/Sources/FieldSpec.swift
+++ b/Sources/FieldSpec.swift
@@ -74,7 +74,7 @@ open class FieldSpec: PoetSpec, FieldSpecType {
     }
 
     fileprivate func emit(enumType codeWriter: CodeWriter) {
-        let cleanName = name.cleaned(nameCase ?? .paramName)
+        let cleanName = name.cleaned(nameCase ?? .camelCaseName)
         let cbBuilder = CodeBlock.builder()
                     .add(literal: "case")
                     .add(literal: cleanName)
@@ -96,7 +96,7 @@ open class FieldSpec: PoetSpec, FieldSpecType {
     }
 
     fileprivate func emit(classType codeWriter: CodeWriter) {
-        let defaultNameCase: String.Case = construct == .typeAlias ? .typeName : .paramName
+        let defaultNameCase: String.Case = construct == .typeAlias ? .typeName : .camelCaseName
         let cleanName = name.cleaned(nameCase ?? defaultNameCase)
         codeWriter.emit(modifiers: modifiers)
         let cbBuilder = CodeBlock.builder()
@@ -131,7 +131,7 @@ open class FieldSpec: PoetSpec, FieldSpecType {
     }
 
     fileprivate func emit(protocolType codeWriter: CodeWriter) {
-        let defaultNameCase: String.Case = parentType == .enum || construct == .typeAlias ? .typeName : .paramName
+        let defaultNameCase: String.Case = parentType == .enum || construct == .typeAlias ? .typeName : .camelCaseName
         let cleanName = name.cleaned(nameCase ?? defaultNameCase)
         codeWriter.emit(modifiers: modifiers)
         let cbBuilder = CodeBlock.builder()
@@ -164,7 +164,8 @@ open class FieldSpecBuilder: PoetSpecBuilder, Builder, FieldSpecType {
     fileprivate init(name: String, type: TypeName? = nil, construct: Construct? = nil) {
         self.type = type
         let requiredConstruct = construct == nil ? FieldSpecBuilder.defaultConstruct : construct!
-        super.init(name: name.cleaned(.paramName), construct: requiredConstruct)
+        // clean name before using
+        super.init(name: name, construct: requiredConstruct)
     }
 
     open func build() -> Result {

--- a/Sources/MethodSpec.swift
+++ b/Sources/MethodSpec.swift
@@ -128,7 +128,7 @@ open class MethodSpecBuilder: PoetSpecBuilder, Builder, MethodSpecProtocol {
 
     fileprivate init(name: String) {
         // init is a reserved word but is ok as a method name
-        let cleanName = name == "init" || name == "init?"  ? name : name.cleaned(.paramName)
+        let cleanName = name == "init" || name == "init?"  ? name : name.cleaned(.camelCaseName)
         super.init(name: cleanName, construct: MethodSpecBuilder.defaultConstruct)
     }
 

--- a/Sources/ParameterSpec.swift
+++ b/Sources/ParameterSpec.swift
@@ -60,7 +60,7 @@ open class ParameterSpecBuilder: PoetSpecBuilder, Builder, ParameterSpecProtocol
         self.label = label
         self.type = type
         let requiredConstruct = construct == nil || construct! != .mutableParam ? ParameterSpecBuilder.defaultConstruct : construct!
-        super.init(name: name.cleaned(.paramName), construct: requiredConstruct)
+        super.init(name: name.cleaned(.unescapedCamelCaseName), construct: requiredConstruct)
     }
 
     open func build() -> Result {

--- a/Sources/StringExtension.swift
+++ b/Sources/StringExtension.swift
@@ -18,7 +18,8 @@ extension String
 {
     public enum Case {
         case typeName
-        case paramName
+        case camelCaseName          // Variables, method declarations, arguments
+        case unescapedCamelCaseName // Can be used for unescaped param names in methods
         case uppercasedName
     }
 }
@@ -28,12 +29,15 @@ extension StringProtocol {
         switch stringCase {
         case .typeName:
             return ReservedWords.safeWord(PoetUtil.stripSpaceAndPunctuation(self).joined(separator: ""))
-        case .paramName:
+        case .camelCaseName, .unescapedCamelCaseName:
             let cleanedNameChars = PoetUtil.stripSpaceAndPunctuation(self, escapeUppercase: true).joined(separator: "")
             if cleanedNameChars == cleanedNameChars.uppercased() {
                 return cleanedNameChars.lowercased()
             }
-            return PoetUtil.lowercaseFirstChar(cleanedNameChars)
+            if case .unescapedCamelCaseName = stringCase {
+                return PoetUtil.lowercaseFirstChar(cleanedNameChars)
+            }
+            return ReservedWords.safeWord(PoetUtil.lowercaseFirstChar(cleanedNameChars))
         case .uppercasedName:
             let cleanedNameChars = PoetUtil.stripSpaceAndPunctuation(self).joined(separator: "")
             return ReservedWords.safeWord(cleanedNameChars.uppercased())

--- a/Sources/StructSpec.swift
+++ b/Sources/StructSpec.swift
@@ -53,8 +53,9 @@ open class StructSpecBuilder: TypeSpecBuilder, Builder {
                     .add(description: spec.description)
                     .build()
                 )
+                let cleanName = spec.name.cleaned(.camelCaseName)
 
-                cb.add(codeBlock: "self.\(spec.name) = \(spec.name)".toCodeBlock())
+                cb.add(codeBlock: "self.\(cleanName) = \(cleanName)".toCodeBlock())
             }
         }
 

--- a/Tests/FileTests/PoetUtilTests.swift
+++ b/Tests/FileTests/PoetUtilTests.swift
@@ -41,7 +41,7 @@ class PoetUtilTests: XCTestCase {
 
     func testcammelCaseNameWithBrackets() {
         let name = "billing_address[street_line1]"
-        XCTAssertEqual("billingAddressStreetLine1", name.cleaned(.paramName))
+        XCTAssertEqual("billingAddressStreetLine1", name.cleaned(.camelCaseName))
     }
 
     func testCleanTypeNameSpaces() {
@@ -51,22 +51,22 @@ class PoetUtilTests: XCTestCase {
 
     func testCamelCaseName() {
         let name = "test"
-        XCTAssertEqual("test", name.cleaned(.paramName))
+        XCTAssertEqual("test", name.cleaned(.camelCaseName))
     }
 
     func testCamelCaseNameSpaces() {
         let name = "test test test"
-        XCTAssertEqual("testTestTest", name.cleaned(.paramName))
+        XCTAssertEqual("testTestTest", name.cleaned(.camelCaseName))
     }
 
     func testCamelCaseNameUnderscores() {
         let name = "test_test_test"
-        XCTAssertEqual("testTestTest", name.cleaned(.paramName))
+        XCTAssertEqual("testTestTest", name.cleaned(.camelCaseName))
     }
 
     func testCamelCaseNameAllCaps() {
         let name = "TEST_ALL_CAPS"
-        XCTAssertEqual("testAllCaps", name.cleaned(.paramName))
+        XCTAssertEqual("testAllCaps", name.cleaned(.camelCaseName))
     }
 
     func testUppercasedCaseName() {
@@ -76,7 +76,7 @@ class PoetUtilTests: XCTestCase {
 
     func testPeriodsInName() {
         let name = "test.periods.in.name"
-        XCTAssertEqual("testPeriodsInName", name.cleaned(.paramName))
+        XCTAssertEqual("testPeriodsInName", name.cleaned(.camelCaseName))
     }
 
 }


### PR DESCRIPTION
…or using backticks in method params. Make it more clear naming for string clean cases.